### PR TITLE
Add core_ui_enabled check for headless scripting

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 import binaryninjaui
+from binaryninja import core_ui_enabled
 
 if "qt_major_version" in dir(binaryninjaui) and binaryninjaui.qt_major_version == 6:
     from PySide6.QtCore import Qt
@@ -10,6 +11,7 @@ from .notepad import docking
 from .notepad.widget import NotepadDockWidget
 
 
-docking.register_widget(
-    NotepadDockWidget, "Notepad", Qt.RightDockWidgetArea, Qt.Vertical, False
-)
+if core_ui_enabled():
+    docking.register_widget(
+        NotepadDockWidget, "Notepad", Qt.RightDockWidgetArea, Qt.Vertical, False
+    )


### PR DESCRIPTION
I noticed that this plugin was causing the exception listed below when I was doing headless scripting (because Binary Ninja will still load all the plugins). This adds a check to see if the UI is loaded before trying to register widgets and prevents the exception.

```
Traceback (most recent call last):
  File "/home/user/.binaryninja/plugins/bn-notepad/__init__.py", line 13, in <module>
    docking.register_widget(
  File "/home/user/.binaryninja/plugins/bn-notepad/notepad/docking.py", line 80, in register_widget
    dock_handler.addDockWidget(
AttributeError: 'NoneType' object has no attribute 'addDockWidget'
```